### PR TITLE
Using react preset instead of jsx plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "plugins": ["transform-react-jsx"],
-  "presets": ["es2015"]
+  "presets": ["es2015", "react"]
 }


### PR DESCRIPTION
See http://babeljs.io/docs/plugins/preset-react/

The `react` preset has some essential plugins.
```
syntax-flow
syntax-jsx
transform-flow-strip-types
transform-react-jsx
transform-react-display-name
```