### PR TITLE
Fix lint, use containsMatchingElement

### DIFF
--- a/.eslintrc-chai-plugin-tests
+++ b/.eslintrc-chai-plugin-tests
@@ -3,3 +3,4 @@ extends:
   - "defaults/configurations/walmart/es6-react-test"
 rules:
   "no-unused-expressions": 0
+  "no-magic-numbers": 0

--- a/karma.config.js
+++ b/karma.config.js
@@ -21,6 +21,7 @@ module.exports = function (config) {
       externals: {
         jsdom: "window",
         cheerio: "window",
+        "react/addons": true,
         "react/lib/ExecutionEnvironment": true,
         "react/lib/ReactContext": true
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "chai": "^3.2.0",
-    "eslint": "^2.9.0",
+    "eslint": "^1.10.3",
     "eslint-config-defaults": "^9.0.0",
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-react": "^5.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ var plugin = function (chai, utils, enzyme) {
     var component = utils.flag(this, SHALLOW_FLAG);
     if (component) {
       this.assert(
-        component.contains(contained),
+        component.containsMatchingElement(contained),
         "expected " + component.html() + " to contain " + contained,
         "expected #{this} to not be #{exp}"
       );


### PR DESCRIPTION
* Fix `contains` assertion by switching to `containsMatchingElement` for Enzyme 2.3.0 compatibility.
* Fix lint by downgrading to `eslint` 1.x (`eslint-config-defaults` is not yet compatible with 2.x).
* Fix lint by disabling `no-magic-numbers` in tests. 
* Fix `test-client` error by adding `react/addons` to `externals`.

/cc @ananavati @benbayard @iamdustan @ryan-roemer 